### PR TITLE
change zScore calculation

### DIFF
--- a/client/src/components/heatmap/Day.tsx
+++ b/client/src/components/heatmap/Day.tsx
@@ -30,20 +30,20 @@ const DayHeatmap = ({ data, stats, dayOnClick }: DayHeatmapProps) => {
   let cellColor: string;
   if (numberOfSongsPlayed === 0) {
     cellColor = 'bg-gray-100 border-gray-300 dark:bg-gray-700 dark:border-gray-500';
-  } else if (zScore <= -3) {
+  } else if (zScore <= -1.5) {
     cellColor = 'bg-green-50 border-green-200';
-  } else if (zScore <= -2) {
-    cellColor = 'bg-green-100 border-green-300';
   } else if (zScore <= -1) {
+    cellColor = 'bg-green-100 border-green-300';
+  } else if (zScore <= -0.5) {
     cellColor = 'bg-green-200 border-green-500';
   } else if (zScore <= 0) {
     cellColor = 'bg-green-400 border-green-600';
-  } else if (zScore <= 1) {
+  } else if (zScore <= 0.5) {
     cellColor = 'bg-green-500 border-green-700';
-  } else if (zScore <= 2) {
+  } else if (zScore <= 1) {
     cellColor = 'bg-green-700 border-green-900';
   } else {
-    cellColor = 'bg-green-900 border-black';
+    cellColor = 'bg-green-800 border-black';
   }
 
   const formatMinutes = (mins: number): string => {

--- a/client/src/components/heatmap/Day.tsx
+++ b/client/src/components/heatmap/Day.tsx
@@ -29,7 +29,7 @@ const DayHeatmap = ({ data, stats, dayOnClick }: DayHeatmapProps) => {
   // https://tailwindcss.com/docs/content-configuration#class-detection-in-depth:~:text=exist%20in%20full%3A-,Always%20use%20complete%20class%20names,-%3Cdiv%20class
   let cellColor: string;
   if (numberOfSongsPlayed === 0) {
-    cellColor = 'bg-gray-100 border-gray-300 dark:bg-gray-700 dark:border-gray-500';
+    cellColor = 'bg-gray-100 border-gray-300 dark:bg-gray-700 dark:border-gray-700';
   } else if (zScore <= -1.5) {
     cellColor = 'bg-green-50 border-green-200';
   } else if (zScore <= -1) {

--- a/client/src/components/heatmap/Day.tsx
+++ b/client/src/components/heatmap/Day.tsx
@@ -29,7 +29,7 @@ const DayHeatmap = ({ data, stats, dayOnClick }: DayHeatmapProps) => {
   // https://tailwindcss.com/docs/content-configuration#class-detection-in-depth:~:text=exist%20in%20full%3A-,Always%20use%20complete%20class%20names,-%3Cdiv%20class
   let cellColor: string;
   if (numberOfSongsPlayed === 0) {
-    cellColor = 'bg-gray-100 border-gray-300 dark:bg-gray-700 dark:border-gray-700';
+    cellColor = 'bg-gray-100 border-gray-300 dark:bg-gray-700 dark:border-gray-600';
   } else if (zScore <= -1.5) {
     cellColor = 'bg-green-50 border-green-200';
   } else if (zScore <= -1) {


### PR DESCRIPTION
The current shades of green do not provide the desired distinction between varying # of streams. Change how we use the zScore to determine which shade to render.