### PR TITLE
Fix: replace googleapis with @googleapis/youtube

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10722,6 +10722,7 @@
     "spotify-api": {
       "version": "file:../spotify-api",
       "requires": {
+        "@googleapis/youtube": "^11.0.1",
         "axios": "^1.2.2",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -11642,6 +11643,14 @@
             "@jridgewell/trace-mapping": "0.3.9"
           }
         },
+        "@googleapis/youtube": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/@googleapis/youtube/-/youtube-11.0.1.tgz",
+          "integrity": "sha512-xbA9u6ig0T4KWsWp3k9gNFZiIdtMewSK5AhofV2lMCLTl+fCdgJNpkaLsZTpdGwe7eg4r05qvhuCISXk5Ql3Hw==",
+          "requires": {
+            "googleapis-common": "^7.0.0"
+          }
+        },
         "@jridgewell/resolve-uri": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
@@ -11794,6 +11803,29 @@
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
           "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
         },
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "requires": {
+            "debug": "^4.3.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            }
+          }
+        },
         "anymatch": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -11837,6 +11869,11 @@
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "bignumber.js": {
+          "version": "9.1.2",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+          "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
         },
         "binary-extensions": {
           "version": "2.2.0",
@@ -11901,6 +11938,11 @@
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
           }
+        },
+        "buffer-equal-constant-time": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+          "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
         },
         "bytes": {
           "version": "3.1.2",
@@ -12013,6 +12055,14 @@
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
           "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
         },
+        "ecdsa-sig-formatter": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+          "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
         "ee-first": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -12070,6 +12120,11 @@
             "utils-merge": "1.0.1",
             "vary": "~1.1.2"
           }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "fast-xml-parser": {
           "version": "4.0.11",
@@ -12132,6 +12187,26 @@
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
           "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
+        "gaxios": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.1.tgz",
+          "integrity": "sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==",
+          "requires": {
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^7.0.1",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.9"
+          }
+        },
+        "gcp-metadata": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.0.0.tgz",
+          "integrity": "sha512-Ozxyi23/1Ar51wjUT2RDklK+3HxqDr8TLBNK8rBBFQ7T85iIGnXnVusauj06QyqCXRFZig8LZC+TUddWbndlpQ==",
+          "requires": {
+            "gaxios": "^6.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
         "get-intrinsic": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
@@ -12148,6 +12223,49 @@
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "requires": {
             "is-glob": "^4.0.1"
+          }
+        },
+        "google-auth-library": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.0.0.tgz",
+          "integrity": "sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "gaxios": "^6.0.0",
+            "gcp-metadata": "^6.0.0",
+            "gtoken": "^7.0.0",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "googleapis-common": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.0.0.tgz",
+          "integrity": "sha512-58iSybJPQZ8XZNMpjrklICefuOuyJ0lMxfKmBqmaC0/xGT4SiOs4BE60LAOOGtBURy1n8fHa2X2YUNFEWWbXyQ==",
+          "requires": {
+            "extend": "^3.0.2",
+            "gaxios": "^6.0.3",
+            "google-auth-library": "^9.0.0",
+            "qs": "^6.7.0",
+            "url-template": "^2.0.8",
+            "uuid": "^9.0.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "9.0.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+              "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+            }
+          }
+        },
+        "gtoken": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+          "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
+          "requires": {
+            "gaxios": "^6.0.0",
+            "jws": "^4.0.0"
           }
         },
         "has": {
@@ -12178,6 +12296,30 @@
             "setprototypeof": "1.2.0",
             "statuses": "2.0.1",
             "toidentifier": "1.0.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            }
           }
         },
         "iconv-lite": {
@@ -12239,10 +12381,50 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        },
+        "json-bigint": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+          "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+          "requires": {
+            "bignumber.js": "^9.0.0"
+          }
+        },
+        "jwa": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+          "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+          "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+          "requires": {
+            "jwa": "^2.0.0",
+            "safe-buffer": "^5.0.1"
+          }
+        },
         "kareem": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
           "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA=="
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
         },
         "make-error": {
           "version": "1.3.6",
@@ -12375,6 +12557,35 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
           "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+        },
+        "node-fetch": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          },
+          "dependencies": {
+            "tr46": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+              "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+            },
+            "webidl-conversions": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+              "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+            },
+            "whatwg-url": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+              "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+              "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+              }
+            }
+          }
         },
         "nodemon": {
           "version": "2.0.20",
@@ -12723,6 +12934,11 @@
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
         },
+        "url-template": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+          "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
+        },
         "utils-merge": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -12757,6 +12973,11 @@
             "tr46": "^3.0.0",
             "webidl-conversions": "^7.0.0"
           }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yn": {
           "version": "3.1.1",

--- a/spotify-api/controllers/youtubePlaylist.ts
+++ b/spotify-api/controllers/youtubePlaylist.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { google, youtube_v3 } from 'googleapis';
+import { youtube, youtube_v3 } from '@googleapis/youtube';
 import { GOOGLE_CLIENT_SECRET } from '../constants';
 
 type YoutubePlaylistItem = {
@@ -13,7 +13,7 @@ class YoutubePlaylistManager {
   private youtube_v3API: youtube_v3.Youtube;
 
   constructor() {
-    this.youtube_v3API = google.youtube({
+    this.youtube_v3API = youtube({
       version: 'v3',
       auth: GOOGLE_CLIENT_SECRET,
     });

--- a/spotify-api/package-lock.json
+++ b/spotify-api/package-lock.json
@@ -919,6 +919,14 @@
         "@jridgewell/trace-mapping": "0.3.9"
       }
     },
+    "@googleapis/youtube": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@googleapis/youtube/-/youtube-11.0.1.tgz",
+      "integrity": "sha512-xbA9u6ig0T4KWsWp3k9gNFZiIdtMewSK5AhofV2lMCLTl+fCdgJNpkaLsZTpdGwe7eg4r05qvhuCISXk5Ql3Hw==",
+      "requires": {
+        "googleapis-common": "^7.0.0"
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
@@ -1545,15 +1553,6 @@
         "gtoken": "^7.0.0",
         "jws": "^4.0.0",
         "lru-cache": "^6.0.0"
-      }
-    },
-    "googleapis": {
-      "version": "126.0.1",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-126.0.1.tgz",
-      "integrity": "sha512-4N8LLi+hj6ytK3PhE52KcM8iSGhJjtXnCDYB4fp6l+GdLbYz4FoDmx074WqMbl7iYMDN87vqD/8drJkhxW92mQ==",
-      "requires": {
-        "google-auth-library": "^9.0.0",
-        "googleapis-common": "^7.0.0"
       }
     },
     "googleapis-common": {

--- a/spotify-api/package.json
+++ b/spotify-api/package.json
@@ -12,10 +12,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@googleapis/youtube": "^11.0.1",
     "axios": "^1.2.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "googleapis": "^126.0.1",
     "mongoose": "^6.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The googleapis dependency is large (`spotify-api/node_modules` was ~129M before). Replace with @googleapis/youtube
 since it is the only module we use (now `spotify-api/node_modules` is ~33M).